### PR TITLE
Configures Maven Central deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,17 +17,25 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # 🔧 clé GPG
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}   # 🔧 passphrase
 
-      - name: Set version
+      - name: Set version from Git tag
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }}
 
-      - name: Build with Maven
-        run: mvn clean package
+      - name: Import GPG key
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Deploy to Maven Central
+      - name: Build and deploy to Maven Central
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.MAVEN_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           mkdir -p $HOME/.m2
           cat > $HOME/.m2/settings.xml <<EOF
@@ -41,4 +49,6 @@ jobs:
             </servers>
           </settings>
           EOF
-          mvn deploy -DskipTests --settings $HOME/.m2/settings.xml -e
+          mvn clean deploy -Prelease -DskipTests \
+            -Dgpg.passphrase="$GPG_PASSPHRASE" \
+            --settings $HOME/.m2/settings.xml -e

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,9 @@
   <packaging>jar</packaging>
   <version>1.0.0</version>
   <name>ikoddi-java-sdk</name>
-  <url>http://maven.apache.org</url>
   <description>Java SDK for interacting with Kreezus platform</description>
+  <url>https://github.com/kreezus/ikoddi-java-sdk</url> <!-- 🔧 MODIF: URL réelle du projet -->
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -20,12 +21,20 @@
   <developers>
     <developer>
       <id>kreezus</id>
-      <name>kreezus</name>
+      <name>Kreezus</name>
       <email>contact@kreezus.com</email>
       <organization>Kreezus</organization>
       <organizationUrl>https://kreezus.com</organizationUrl>
     </developer>
   </developers>
+
+  <!-- 🔧 MODIF: SCM obligatoire pour Maven Central -->
+  <scm>
+    <url>https://github.com/kreezus/ikoddi-java-sdk</url>
+    <connection>scm:git:git://github.com/kreezus/ikoddi-java-sdk.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/kreezus/ikoddi-java-sdk.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -46,38 +55,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
-        <plugin>
-          <groupId>org.sonatype.central</groupId>
-          <artifactId>central-publishing-maven-plugin</artifactId>
-          <version>0.8.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <publishingServerId>central</publishingServerId>
-            <tokenAuth>true</tokenAuth>
-            <autoPublish>true</autoPublish>
-          </configuration>
-        </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <tokenAuth>true</tokenAuth>
+          <autoPublish>true</autoPublish>
+        </configuration>
+      </plugin>
     </plugins>
-</build>
+  </build>
 
   <profiles>
     <profile>
       <id>release</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>central</publishingServerId>
-              <tokenAuth>true</tokenAuth>
-              <autoPublish>true</autoPublish>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
@@ -92,6 +94,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
@@ -105,10 +108,10 @@
               </execution>
             </executions>
             <configuration>
-              <stylesheet>java</stylesheet>
               <doclint>none</doclint>
             </configuration>
           </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Updates the workflow to properly deploy the library to Maven Central.

This includes configuring GPG key import for signing, setting the correct Maven deploy goals and parameters, and adding necessary SCM information to the POM file.  The release profile is activated by default, ensuring the proper plugins are used during deployment.  The project URL is also updated in the POM.